### PR TITLE
feat(vim): introduce package-lsp-swift

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -301,6 +301,14 @@ if executable('sourcekit-lsp')
         \ })
 endif
 
+if executable('package-swift-lsp')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'package-swift-lsp',
+        \ 'cmd': {server_info->['package-swift-lsp']},
+        \ 'allowlist': ['swift'],
+        \ })
+endif
+
 function! s:on_lsp_buffer_enabled() abort
     setlocal omnifunc=lsp#complete
     setlocal signcolumn=yes


### PR DESCRIPTION
[package-swift-lsp](https://github.com/kattouf/package-swift-lsp) is a language server for Package.swift. This helps me edit Package.swift in Vim.

I don't know how to make this affect only Package.swift and Package.swift-*.swift and not all Swift files.